### PR TITLE
Allow parsing of player UUID

### DIFF
--- a/AATool/Net/Player.cs
+++ b/AATool/Net/Player.cs
@@ -20,7 +20,7 @@ namespace AATool.Net
         private static readonly HashSet<string> NamesAlreadyRequested = new ();
         private static readonly HashSet<Uuid> IdentitiesAlreadyRequested = new ();
 
-        public static bool TryGetUuid(string name, out Uuid id) => IdCache.TryGetValue(name ?? "", out id);
+        public static bool TryGetUuid(string name, out Uuid id) => Uuid.TryParse(name, out id) || IdCache.TryGetValue(name ?? "", out id);
         public static bool TryGetName(Uuid id, out string name) => NameCache.TryGetValue(id, out name);
         public static bool TryGetColor(Uuid id, out Color color) => IdColorCache.TryGetValue(id, out color);
         public static bool TryGetColor(string name, out Color color) => NameColorCache.TryGetValue(name ?? "", out color);

--- a/AATool/Winforms/Controls/CTrackerSettings.Designer.cs
+++ b/AATool/Winforms/Controls/CTrackerSettings.Designer.cs
@@ -1,4 +1,4 @@
-﻿
+
 namespace AATool.Winforms.Controls
 {
     partial class CTrackerSettings
@@ -585,7 +585,7 @@ namespace AATool.Winforms.Controls
             this.label10.Name = "label10";
             this.label10.Size = new System.Drawing.Size(82, 13);
             this.label10.TabIndex = 75;
-            this.label10.Text = "Your MC Name:";
+            this.label10.Text = "Username / UUID:";
             // 
             // filterSolo
             // 


### PR DESCRIPTION
This allows for parsing of direct player UUID for servers, when the server is in offline-mode and you want to filter a specific player.

This feature already exists when clicking the player head on the main screen, but didn't work when filtering on config.