### PR TITLE
[FIX] Fix SFTP connection against builtin Windows SFTP server

### DIFF
--- a/AATool/Saves/MinecraftServer.cs
+++ b/AATool/Saves/MinecraftServer.cs
@@ -84,7 +84,6 @@ namespace AATool.Saves
                         return;
                     if (!TryGetWorldSaveTime(sftp, out DateTime latest))
                         return;
-
                     DateTime next = latest.Add(TimeSpan.FromSeconds(SaveInterval));
                     remaining = (next - DateTime.UtcNow).TotalSeconds;
                     if (remaining > 0)
@@ -278,10 +277,10 @@ namespace AATool.Saves
                 //download server properties
                 string path = Path.Combine(Config.Sftp.ServerRoot, "server.properties");
                 string[] properties = sftp.ReadAllText(path).Split('\n');
-                if (TryGetProperty(properties, "level-name", out string word))
-                    WorldName = word;
+                if (TryGetProperty(properties, "level-name", out string world))
+                    WorldName = world.TrimEnd();
                 if (TryGetProperty(properties, "motd", out string message))
-                    MessageOfTheDay = message;
+                    MessageOfTheDay = message.TrimEnd();
                 return true;
             }
             catch (Exception exception)
@@ -304,7 +303,7 @@ namespace AATool.Saves
         private static bool TryGetWorldSaveTime(SftpClient sftp, out DateTime lastWorldSave, int failures = 0)
         {
             SetState(SyncState.LastAutoSave);
-            string remote = Path.Combine(Config.Sftp.ServerRoot, $"{WorldName}/level.dat");
+            string remote = Path.Combine(Config.Sftp.ServerRoot, WorldName, "level.dat");
             lastWorldSave = default;
 
             try
@@ -346,7 +345,7 @@ namespace AATool.Saves
             SmoothDownloadPercent = 0;
 
             string localPath = Path.Combine(Paths.System.SftpWorldsFolder, WorldName, name);
-            string remotePath = Path.Combine(Config.Sftp.ServerRoot, $"{WorldName}/{name}");
+            string remotePath = Path.Combine(Config.Sftp.ServerRoot, WorldName, name);
             try
             {
                 //make sure directory exists


### PR DESCRIPTION
Some fixes I had to do to make this work agains a built-in SFTP server running on my Windows 10 machine (using native OpenSSH server that is running sftp-server.exe under the hood).

Also, I added those `.TrimEnd()` to the properties that are being gathered from the server because those were coming with a newline at the end in my environment.

Feel free to ask anything, or request changes if needed.

Fixes #62 