### PR TITLE
Improve efficiency of `Saves.CurrentFolder` method.

### DIFF
--- a/AATool/Paths.cs
+++ b/AATool/Paths.cs
@@ -100,6 +100,7 @@ namespace AATool
         public static class Saves
         {
             public const string AppDataShortcut = "%AppData%\\Roaming";
+            private static readonly string AppDataFolderPath = GetFolderPath(SpecialFolder.ApplicationData);
 
             public static string CurrentFolder()
             {
@@ -107,7 +108,7 @@ namespace AATool
                     return System.SftpWorldsFolder;
 
                 return Tracker.Source is TrackerSource.CustomSavesPath
-                    ? Config.Tracking.CustomSavesPath.Value.Replace(AppDataShortcut, GetFolderPath(SpecialFolder.ApplicationData))
+                    ? Config.Tracking.CustomSavesPath.Value.Replace(AppDataShortcut, AppDataFolderPath)
                     : ActiveInstance.SavesPath;
             }
 


### PR DESCRIPTION
As it stands, the `Saves.CurrentFolder` method is quite inefficient. It has a noticeable impact on the application's performance. Under the hood, `Environment.GetFolderPath` method makes a call to the shell32 API; `Saves.CurrentFolder` spends the vast majority of its time on this call (according to dotTrace, over 90% of the call to `Saves.CurrentFolder` was spent on `Environment.GetFolderPath`). 

Computing this value once at runtime and storing it in a field is a significant improvement; the total time spent executing `Saves.CurrentFolder` is now insignificant in the scope of the whole application (according to dotTrace, it's now less than 0.01% of total execution time of the whole application).