### PR TITLE
Replace "High-Res Display Scaling" with adjustable "Zoom" option

### DIFF
--- a/AATool/Configuration/MainConfig.cs
+++ b/AATool/Configuration/MainConfig.cs
@@ -41,11 +41,20 @@ namespace AATool.Configuration
                 {"High Contrast",  (Hex("000000"), Hex("FFFFFF"), Hex("FFFFFF"))}
             };
 
+            public static readonly Dictionary<string, double> DisplayScales = new ()
+            {
+                {"100%", 1 },
+                {"125%", 1.25 },
+                {"150%", 1.5 },
+                {"175%", 1.75 },
+                {"200%", 2 },
+            };
+
             private static Color Hex(string hex) => 
                 ColorHelper.TryGetHexColor(hex, out Color color) ? color : Color.White;
 
             [JsonProperty] public readonly Setting<int> FpsCap = new (60);
-            [JsonProperty] public readonly Setting<int> DisplayScale = new (1);
+            [JsonProperty] public readonly Setting<double> DisplayScale = new (1);
 
             [JsonProperty] public readonly Setting<bool> AllowUserResizing = new (false);
             [JsonProperty] public readonly Setting<bool> HideCompletedAdvancements = new (false);

--- a/AATool/UI/Screens/UIMainScreen.cs
+++ b/AATool/UI/Screens/UIMainScreen.cs
@@ -297,7 +297,9 @@ namespace AATool.UI.Screens
                 RenderCache?.Dispose();
                 RenderCache = new RenderTarget2D(this.GraphicsDevice, width, height);
             }
-            this.Form.ClientSize = new System.Drawing.Size(width * Config.Main.DisplayScale, height * Config.Main.DisplayScale);
+            int clientWidth = Convert.ToInt32(Convert.ToDouble(width) * Config.Main.DisplayScale);
+            int clientHeight = Convert.ToInt32(Convert.ToDouble(height) * Config.Main.DisplayScale);
+            this.Form.ClientSize = new System.Drawing.Size(clientWidth, clientHeight);
 
             //snap window to user's preferred location
             if (!this.Positioned || Config.Main.StartupArrangement.Changed || Config.Main.StartupDisplay.Changed)

--- a/AATool/Winforms/Controls/CMainSettings.Designer.cs
+++ b/AATool/Winforms/Controls/CMainSettings.Designer.cs
@@ -34,7 +34,8 @@ namespace AATool.Winforms.Controls
             this.alwaysOnTop = new System.Windows.Forms.CheckBox();
             this.configureAutoSwitch = new System.Windows.Forms.Button();
             this.hideCompletedCriteria = new System.Windows.Forms.CheckBox();
-            this.highRes = new System.Windows.Forms.CheckBox();
+            this.highResLabel = new System.Windows.Forms.Label();
+            this.highRes = new System.Windows.Forms.ComboBox();
             this.label3 = new System.Windows.Forms.Label();
             this.infoPanel = new System.Windows.Forms.ComboBox();
             this.label12 = new System.Windows.Forms.Label();
@@ -80,7 +81,7 @@ namespace AATool.Winforms.Controls
             // notesEnabled
             // 
             this.notesEnabled.AutoSize = true;
-            this.notesEnabled.Location = new System.Drawing.Point(8, 190);
+            this.notesEnabled.Location = new System.Drawing.Point(9, 165);
             this.notesEnabled.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
             this.notesEnabled.Name = "notesEnabled";
             this.notesEnabled.Size = new System.Drawing.Size(126, 17);
@@ -94,6 +95,7 @@ namespace AATool.Winforms.Controls
             this.mainGroupMain.Controls.Add(this.alwaysOnTop);
             this.mainGroupMain.Controls.Add(this.configureAutoSwitch);
             this.mainGroupMain.Controls.Add(this.hideCompletedCriteria);
+            this.mainGroupMain.Controls.Add(this.highResLabel);
             this.mainGroupMain.Controls.Add(this.highRes);
             this.mainGroupMain.Controls.Add(this.label3);
             this.mainGroupMain.Controls.Add(this.infoPanel);
@@ -113,7 +115,7 @@ namespace AATool.Winforms.Controls
             // alwaysOnTop
             // 
             this.alwaysOnTop.AutoSize = true;
-            this.alwaysOnTop.Location = new System.Drawing.Point(8, 165);
+            this.alwaysOnTop.Location = new System.Drawing.Point(9, 140);
             this.alwaysOnTop.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
             this.alwaysOnTop.Name = "alwaysOnTop";
             this.alwaysOnTop.Size = new System.Drawing.Size(98, 17);
@@ -143,18 +145,30 @@ namespace AATool.Winforms.Controls
             this.hideCompletedCriteria.Text = "Hide Completed Criteria";
             this.hideCompletedCriteria.UseVisualStyleBackColor = true;
             this.hideCompletedCriteria.CheckedChanged += new System.EventHandler(this.OnCheckChanged);
-            // 
+
+            //
+            // highResLabel
+            //
+
+            this.highResLabel.AutoSize = true;
+            this.highResLabel.Location = new System.Drawing.Point(191, 22);
+            this.highResLabel.Margin = new System.Windows.Forms.Padding(3, 6, 3, 0);
+            this.highResLabel.Name = "highResLabel";
+            this.highResLabel.Size = new System.Drawing.Size(54, 13);
+            this.highResLabel.TabIndex = 49;
+            this.highResLabel.Text = "Zoom:";
+
+            //
             // highRes
             // 
-            this.highRes.AutoSize = true;
-            this.highRes.Location = new System.Drawing.Point(8, 140);
-            this.highRes.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.highRes.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.highRes.FormattingEnabled = true;
+            this.highRes.Location = new System.Drawing.Point(191, 38);
             this.highRes.Name = "highRes";
-            this.highRes.Size = new System.Drawing.Size(133, 17);
+            this.highRes.Size = new System.Drawing.Size(54, 17);
             this.highRes.TabIndex = 38;
-            this.highRes.Text = "Hi-Res Display Scaling";
-            this.highRes.UseVisualStyleBackColor = true;
-            this.highRes.CheckedChanged += new System.EventHandler(this.OnCheckChanged);
+            this.highRes.SelectedIndexChanged += new System.EventHandler(this.OnIndexChanged);
+
             // 
             // label3
             // 
@@ -183,7 +197,7 @@ namespace AATool.Winforms.Controls
             // 
             this.label12.AutoSize = true;
             this.label12.ForeColor = System.Drawing.SystemColors.WindowFrame;
-            this.label12.Location = new System.Drawing.Point(4, 208);
+            this.label12.Location = new System.Drawing.Point(5, 181);
             this.label12.Margin = new System.Windows.Forms.Padding(0, 0, 3, 10);
             this.label12.Name = "label12";
             this.label12.Size = new System.Drawing.Size(221, 13);
@@ -643,7 +657,8 @@ namespace AATool.Winforms.Controls
         private System.Windows.Forms.ComboBox progressBarStyle;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.ComboBox infoPanel;
-        private System.Windows.Forms.CheckBox highRes;
+        private System.Windows.Forms.Label highResLabel;
+        private System.Windows.Forms.ComboBox highRes;
         private System.Windows.Forms.Label label14;
         private System.Windows.Forms.Label label15;
         private System.Windows.Forms.ComboBox startupPosition;

--- a/AATool/Winforms/Controls/CMainSettings.cs
+++ b/AATool/Winforms/Controls/CMainSettings.cs
@@ -35,7 +35,6 @@ namespace AATool.Winforms.Controls
             this.viewMode.Text          = Main.TextInfo.ToTitleCase(Config.Main.Layout.Value);
             this.hideBasic.Checked      = !Config.Main.ShowBasicAdvancements;
             this.ambientGlow.Checked    = Config.Main.ShowAmbientGlow;
-            this.highRes.Checked        = Config.Main.DisplayScale > 1;
             this.frameStyle.Text        = Config.Main.FrameStyle;
             this.progressBarStyle.Text  = Config.Main.ProgressBarStyle;
             this.refreshIcon.Text       = Config.Main.RefreshIcon;
@@ -50,6 +49,15 @@ namespace AATool.Winforms.Controls
             this.UpdateMonitorList();
             this.startupMonitor.SelectedIndex = MathHelper.Clamp(Config.Main.StartupDisplay - 1, 0, this.startupMonitor.Items.Count - 1);
             this.startupMonitor.Enabled = this.startupPosition.Text != "Remember";
+
+            // display scale
+            this.highRes.Items.Clear();
+            foreach (KeyValuePair<string, double> displayScale in Config.MainConfig.DisplayScales)
+            {
+                this.highRes.Items.Add(displayScale.Key);
+                if (Config.Main.DisplayScale == displayScale.Value)
+                    this.highRes.Text = displayScale.Key;
+            }
 
             //colors
             this.theme.Items.Clear();
@@ -82,7 +90,6 @@ namespace AATool.Winforms.Controls
                 Config.Main.HideCompletedAdvancements.Set(this.hideCompletedAdvancements.Checked);
                 Config.Main.HideCompletedCriteria.Set(this.hideCompletedCriteria.Checked);
                 Config.Main.ShowAmbientGlow.Set(this.ambientGlow.Checked);
-                Config.Main.DisplayScale.Set(this.highRes.Checked ? 2 : 1);
                 Config.Main.Layout.Set(this.viewMode.Text.ToLower());
                 Config.Main.FrameStyle.Set(this.frameStyle.Text);
                 Config.Main.ProgressBarStyle.Set(this.progressBarStyle.Text);
@@ -317,6 +324,18 @@ namespace AATool.Winforms.Controls
                     this.textColor.BackColor   = ColorHelper.ToDrawing(Config.Main.TextColor);
                     this.borderColor.BackColor = ColorHelper.ToDrawing(Config.Main.BorderColor);
                     Config.Main.RainbowMode.Set(false);
+                }
+            }
+            if (sender == this.highRes)
+            {
+                string displayScaleText = this.highRes.Text;
+                if (Config.MainConfig.DisplayScales.TryGetValue(displayScaleText, out double displayScale))
+                {
+                    Config.Main.DisplayScale.Set(displayScale);
+                }
+                else
+                {
+                    Config.Main.DisplayScale.Set(1);
                 }
             }
             else if (sender == this.startupPosition)


### PR DESCRIPTION
Replaces the "High-Res Display Scaling" checkbox with a "Zoom" combo box so that the scaling is adjustable.

![image](https://github.com/DarwinBaker/AATool/assets/3529874/d6e71b4c-1b88-42e1-9c3b-8a953f93d90c)

My purpose behind doing this is that I have a small 1440p display and the font is unreadable without squinting, but the current high-res display scaling option makes the window too large to fit on the display.